### PR TITLE
Add OIDC login flow and authentication provider

### DIFF
--- a/goalise/src/app/provider.tsx
+++ b/goalise/src/app/provider.tsx
@@ -2,7 +2,12 @@
 
 import { Provider } from "react-redux";
 import { store } from "./store/store";
+import { AuthProvider } from "@/shared/auth/AuthContext";
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <Provider store={store}>{children}</Provider>;
+  return (
+    <Provider store={store}>
+      <AuthProvider>{children}</AuthProvider>
+    </Provider>
+  );
 }

--- a/goalise/src/app/signin-oidc/page.tsx
+++ b/goalise/src/app/signin-oidc/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { handleSignInCallback } from "@/shared/auth/oidcService";
+import { useAuth } from "@/shared/auth/AuthContext";
+
+const SignInOidcPage = () => {
+  const router = useRouter();
+  const { updateTokens } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { tokens, returnPath } = await handleSignInCallback(
+          window.location.href
+        );
+        updateTokens(tokens);
+        router.replace(returnPath || "/");
+      } catch (err) {
+        console.error("Sign-in callback failed", err);
+        setError(err instanceof Error ? err.message : "Unexpected error");
+        updateTokens(null);
+      }
+    })();
+  }, [router, updateTokens]);
+
+  if (error) {
+    return (
+      <div style={{ padding: "24px" }}>
+        <h2>Sign-in failed</h2>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "24px" }}>
+      <h2>Completing sign-in...</h2>
+      <p>Please wait while we process your login.</p>
+    </div>
+  );
+};
+
+export default SignInOidcPage;

--- a/goalise/src/app/signout-callback-oidc/page.tsx
+++ b/goalise/src/app/signout-callback-oidc/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { handleSignOutCallback } from "@/shared/auth/oidcService";
+import { useAuth } from "@/shared/auth/AuthContext";
+
+const SignOutCallbackPage = () => {
+  const router = useRouter();
+  const { updateTokens } = useAuth();
+
+  useEffect(() => {
+    const next = handleSignOutCallback(window.location.href);
+    updateTokens(null);
+    router.replace(next || "/");
+  }, [router, updateTokens]);
+
+  return (
+    <div style={{ padding: "24px" }}>
+      <h2>Signing you out...</h2>
+      <p>You will be redirected shortly.</p>
+    </div>
+  );
+};
+
+export default SignOutCallbackPage;

--- a/goalise/src/components/generalComponents/Header/Header.module.css
+++ b/goalise/src/components/generalComponents/Header/Header.module.css
@@ -65,6 +65,38 @@
   align-items: center;
 }
 
+.profile_details {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.user_name {
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.auth_button {
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid #a5a5a5;
+  color: #ffffff;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background-color 160ms ease, color 160ms ease, opacity 160ms ease;
+}
+
+.auth_button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.auth_button:not(:disabled):hover {
+  background-color: #a5a5a5;
+  color: #101010;
+}
+
 .burger_menu_closed {
   display: flex;
   align-items: center;
@@ -193,4 +225,11 @@
 .search_no_results {
   padding: 12px;
   color: rgba(255, 255, 255, 0.6);
+}
+
+.mobile_auth_actions {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
 }

--- a/goalise/src/components/generalComponents/Header/Header.tsx
+++ b/goalise/src/components/generalComponents/Header/Header.tsx
@@ -15,6 +15,7 @@ import { useWindowSize } from "@/hooks/useWindowSize";
 import { MEDIA_TABLET_SMALL } from "@/constants/windowSizes";
 import burgerIcon from "../../../assets/pngs/burgerMenu.png";
 import closeIcon from "../../../assets/pngs/arrowRightIcon.png";
+import { useAuth } from "@/shared/auth/AuthContext";
 
 export const Header = () => {
   const t = useTranslations();
@@ -33,6 +34,7 @@ export const Header = () => {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const searchButtonRef = useRef<HTMLDivElement | null>(null);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const { isAuthenticated, user, signIn, signOut, loading } = useAuth();
 
   useEffect(() => {
     const id = window.setTimeout(() => setDebouncedQuery(query.trim()), 300);
@@ -118,6 +120,22 @@ export const Header = () => {
       return next;
     });
   };
+
+  const getReturnPath = () => {
+    if (typeof window === "undefined") return "/";
+    return `${window.location.pathname}${window.location.search}`;
+  };
+
+  const onAuthClick = () => {
+    if (isAuthenticated) {
+      signOut("/");
+    } else {
+      signIn(getReturnPath());
+    }
+  };
+
+  const userLabel =
+    user?.name || user?.preferred_username || user?.email || "Guest";
 
   return (
     <>
@@ -235,6 +253,23 @@ export const Header = () => {
                       </div>
                     )}
                   </div>
+
+                  <div className={styles.mobile_auth_actions}>
+                    <button
+                      className={styles.auth_button}
+                      onClick={() => {
+                        closeMenu();
+                        onAuthClick();
+                      }}
+                      disabled={loading}
+                    >
+                      {loading
+                        ? "Loading..."
+                        : isAuthenticated
+                          ? "Sign out"
+                          : "Sign in"}
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -343,8 +378,19 @@ export const Header = () => {
               flexItem
             />
             <div className={styles.name_and_img_wrapper}>
-              <div>
-                <span>name surname</span>
+              <div className={styles.profile_details}>
+                <span className={styles.user_name}>{userLabel}</span>
+                <button
+                  className={styles.auth_button}
+                  onClick={onAuthClick}
+                  disabled={loading}
+                >
+                  {loading
+                    ? "Loading..."
+                    : isAuthenticated
+                      ? "Sign out"
+                      : "Sign in"}
+                </button>
               </div>
               <div className={styles.profile_img_wrapper}>
                 <Image src={profileImg} alt="" className={styles.profile_img} />

--- a/goalise/src/components/generalComponents/Header/Header.tsx
+++ b/goalise/src/components/generalComponents/Header/Header.tsx
@@ -135,7 +135,7 @@ export const Header = () => {
   };
 
   const userLabel =
-    user?.name || user?.preferred_username || user?.email || "Guest";
+    user?.name || user?.email || "Guest";
 
   return (
     <>

--- a/goalise/src/shared/auth/AuthContext.tsx
+++ b/goalise/src/shared/auth/AuthContext.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  AuthTokens,
+  clearTokens,
+  getStoredTokens,
+  refreshTokens,
+  startLoginRedirect,
+  startLogoutRedirect,
+  useMemoizedProfile,
+} from "./oidcService";
+
+export type AuthContextValue = {
+  tokens: AuthTokens | null;
+  loading: boolean;
+  isAuthenticated: boolean;
+  user: ReturnType<typeof useMemoizedProfile>;
+  signIn: (returnPath?: string) => Promise<void>;
+  signOut: (returnPath?: string) => void;
+  updateTokens: (tokens: AuthTokens | null) => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: PropsWithChildren) => {
+  const [tokens, setTokens] = useState<AuthTokens | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setTokens(getStoredTokens());
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === "goalize_auth_tokens") {
+        setTokens(getStoredTokens());
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const scheduleRefresh = useCallback(() => {
+    if (!tokens?.expiresAt || !tokens.refreshToken) return undefined;
+    const now = Date.now();
+    const refreshIn = tokens.expiresAt - now - 60_000;
+    if (refreshIn <= 0) {
+      refreshTokens(tokens.refreshToken)
+        .then((t) => setTokens(t))
+        .catch((err) => console.error("Refresh token failed", err));
+      return undefined;
+    }
+    const id = window.setTimeout(() => {
+      refreshTokens(tokens.refreshToken as string)
+        .then((t) => setTokens(t))
+        .catch((err) => {
+          console.error("Refresh token failed", err);
+          clearTokens();
+          setTokens(null);
+        });
+    }, refreshIn);
+    return () => window.clearTimeout(id);
+  }, [tokens?.expiresAt, tokens?.refreshToken]);
+
+  useEffect(() => {
+    const cleanup = scheduleRefresh();
+    return () => {
+      if (cleanup) cleanup();
+    };
+  }, [scheduleRefresh]);
+
+  const signIn = useCallback(async (returnPath?: string) => {
+    await startLoginRedirect(returnPath);
+  }, []);
+
+  const signOut = useCallback(
+    (returnPath?: string) => {
+      const idToken = tokens?.idToken;
+      clearTokens();
+      setTokens(null);
+      startLogoutRedirect(idToken, returnPath);
+    },
+    [tokens?.idToken]
+  );
+
+  const updateTokens = useCallback((newTokens: AuthTokens | null) => {
+    if (!newTokens) {
+      clearTokens();
+      setTokens(null);
+      return;
+    }
+    setTokens(newTokens);
+  }, []);
+
+  const profile = useMemoizedProfile(tokens?.profile);
+
+  const value = useMemo<AuthContextValue>(() => {
+    return {
+      tokens,
+      loading,
+      isAuthenticated: Boolean(tokens?.accessToken),
+      user: profile,
+      signIn,
+      signOut,
+      updateTokens,
+    };
+  }, [tokens, loading, signIn, signOut, updateTokens, profile]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+};

--- a/goalise/src/shared/auth/oidcService.ts
+++ b/goalise/src/shared/auth/oidcService.ts
@@ -117,11 +117,8 @@ const decodeJwtPayload = (token?: string): AuthProfile | undefined => {
   if (parts.length < 2) return undefined;
   try {
     const payload = parts[1];
-    console.log(payload)
     const decoded = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
-    console.log(decoded)
     const json = JSON.parse(decoded);
-    console.log(json)
     return {
       name: json.name || json.given_name || json.family_name,
       email: json.email,
@@ -265,7 +262,7 @@ export const refreshTokens = async (refreshToken: string): Promise<AuthTokens> =
   const json = await response.json();
   const expiresInMs = (json.expires_in ? Number(json.expires_in) : 0) * 1000;
   const expiresAt = Date.now() + expiresInMs;
-  const profile = decodeJwtPayload(json.access_token);
+  const profile = decodeJwtPayload(json.id_token);
 
   const tokens: AuthTokens = {
     accessToken: json.access_token,

--- a/goalise/src/shared/auth/oidcService.ts
+++ b/goalise/src/shared/auth/oidcService.ts
@@ -24,21 +24,14 @@ export type AuthTokens = {
   profile?: AuthProfile;
 };
 
-const getBaseUrl = () => {
-  if (typeof window !== "undefined") return window.location.origin;
-  return process.env.NEXT_PUBLIC_APP_BASE_URL || "https://goalize.duckdns.org";
-};
-
 export const authConfig = {
-  authority: process.env.NEXT_PUBLIC_IDENTITY_AUTHORITY || "https://goalize.duckdns.org",
-  clientId: process.env.NEXT_PUBLIC_IDENTITY_CLIENT_ID || "Goalize-WebApp",
+  authority: process.env.NEXT_PUBLIC_IDENTITY_AUTHORITY,
+  clientId: process.env.NEXT_PUBLIC_IDENTITY_CLIENT_ID,
   redirectUri:
-    process.env.NEXT_PUBLIC_IDENTITY_REDIRECT || `${getBaseUrl()}/signin-oidc`,
+    process.env.NEXT_PUBLIC_IDENTITY_REDIRECT,
   postLogoutRedirectUri:
-    process.env.NEXT_PUBLIC_IDENTITY_LOGOUT_REDIRECT ||
-    `${getBaseUrl()}/signout-callback-oidc`,
+    process.env.NEXT_PUBLIC_IDENTITY_LOGOUT_REDIRECT,
   scope:
-    process.env.NEXT_PUBLIC_IDENTITY_SCOPE ||
     "openid profile email phone offline_access",
 };
 
@@ -124,14 +117,16 @@ const decodeJwtPayload = (token?: string): AuthProfile | undefined => {
   if (parts.length < 2) return undefined;
   try {
     const payload = parts[1];
+    console.log(payload)
     const decoded = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    console.log(decoded)
     const json = JSON.parse(decoded);
+    console.log(json)
     return {
       name: json.name || json.given_name || json.family_name,
       email: json.email,
       phone_number: json.phone_number,
-      picture: json.picture,
-      preferred_username: json.preferred_username,
+      picture: json.picture
     };
   } catch (e) {
     console.error("Unable to decode id_token", e);
@@ -209,7 +204,7 @@ const requestTokens = async (code: string, codeVerifier: string) => {
   const expiresInMs = (json.expires_in ? Number(json.expires_in) : 0) * 1000;
   const expiresAt = Date.now() + expiresInMs;
 
-  const profile = decodeJwtPayload(json.id_token) || decodeJwtPayload(json.access_token);
+  const profile = decodeJwtPayload(json.id_token);
 
   const tokens: AuthTokens = {
     accessToken: json.access_token,
@@ -270,7 +265,7 @@ export const refreshTokens = async (refreshToken: string): Promise<AuthTokens> =
   const json = await response.json();
   const expiresInMs = (json.expires_in ? Number(json.expires_in) : 0) * 1000;
   const expiresAt = Date.now() + expiresInMs;
-  const profile = decodeJwtPayload(json.id_token) || decodeJwtPayload(json.access_token);
+  const profile = decodeJwtPayload(json.access_token);
 
   const tokens: AuthTokens = {
     accessToken: json.access_token,

--- a/goalise/src/shared/auth/oidcService.ts
+++ b/goalise/src/shared/auth/oidcService.ts
@@ -25,12 +25,12 @@ export type AuthTokens = {
 };
 
 export const authConfig = {
-  authority: process.env.NEXT_PUBLIC_IDENTITY_AUTHORITY,
-  clientId: process.env.NEXT_PUBLIC_IDENTITY_CLIENT_ID,
+  authority: process.env.NEXT_PUBLIC_IDENTITY_AUTHORITY || "https://auth-goalize.duckdns.org",
+  clientId: process.env.NEXT_PUBLIC_IDENTITY_CLIENT_ID || "Goalize-WebApp",
   redirectUri:
-    process.env.NEXT_PUBLIC_IDENTITY_REDIRECT,
+    process.env.NEXT_PUBLIC_IDENTITY_REDIRECT || "http://localhost:3000/signin-oidc",
   postLogoutRedirectUri:
-    process.env.NEXT_PUBLIC_IDENTITY_LOGOUT_REDIRECT,
+    process.env.NEXT_PUBLIC_IDENTITY_LOGOUT_REDIRECT || "http://localhost:3000/signout-callback-oidc",
   scope:
     "openid profile email phone offline_access",
 };

--- a/goalise/src/shared/auth/oidcService.ts
+++ b/goalise/src/shared/auth/oidcService.ts
@@ -1,0 +1,320 @@
+"use client";
+
+import { useMemo } from "react";
+
+const AUTH_STORAGE_KEY = "goalize_auth_tokens";
+const PKCE_STATE_PREFIX = "goalize_pkce_state:";
+const LOGOUT_STATE_PREFIX = "goalize_logout_state:";
+
+export type AuthProfile = {
+  name?: string;
+  email?: string;
+  phone_number?: string;
+  picture?: string;
+  preferred_username?: string;
+};
+
+export type AuthTokens = {
+  accessToken: string;
+  refreshToken?: string;
+  idToken?: string;
+  expiresAt: number;
+  scope?: string;
+  tokenType?: string;
+  profile?: AuthProfile;
+};
+
+const getBaseUrl = () => {
+  if (typeof window !== "undefined") return window.location.origin;
+  return process.env.NEXT_PUBLIC_APP_BASE_URL || "https://goalize.duckdns.org";
+};
+
+export const authConfig = {
+  authority: process.env.NEXT_PUBLIC_IDENTITY_AUTHORITY || "https://goalize.duckdns.org",
+  clientId: process.env.NEXT_PUBLIC_IDENTITY_CLIENT_ID || "Goalize-WebApp",
+  redirectUri:
+    process.env.NEXT_PUBLIC_IDENTITY_REDIRECT || `${getBaseUrl()}/signin-oidc`,
+  postLogoutRedirectUri:
+    process.env.NEXT_PUBLIC_IDENTITY_LOGOUT_REDIRECT ||
+    `${getBaseUrl()}/signout-callback-oidc`,
+  scope:
+    process.env.NEXT_PUBLIC_IDENTITY_SCOPE ||
+    "openid profile email phone offline_access",
+};
+
+type PendingAuth = {
+  state: string;
+  codeVerifier: string;
+  returnPath?: string;
+};
+
+type PendingLogout = {
+  state: string;
+  returnPath?: string;
+};
+
+const base64UrlEncode = (buffer: ArrayBuffer) => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  bytes.forEach((b) => (binary += String.fromCharCode(b)));
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+const generateRandomString = (size = 32) => {
+  if (typeof window === "undefined") return "";
+  const array = new Uint8Array(size);
+  crypto.getRandomValues(array);
+  return Array.from(array, (b) => b.toString(16).padStart(2, "0")).join("");
+};
+
+const sha256 = async (plain: string) => {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(plain);
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return base64UrlEncode(hash);
+};
+
+const savePendingAuth = (pending: PendingAuth) => {
+  if (typeof window === "undefined") return;
+  sessionStorage.setItem(
+    `${PKCE_STATE_PREFIX}${pending.state}`,
+    JSON.stringify(pending)
+  );
+};
+
+const consumePendingAuth = (state: string | null): PendingAuth | null => {
+  if (typeof window === "undefined" || !state) return null;
+  const key = `${PKCE_STATE_PREFIX}${state}`;
+  const raw = sessionStorage.getItem(key);
+  if (!raw) return null;
+  sessionStorage.removeItem(key);
+  try {
+    return JSON.parse(raw) as PendingAuth;
+  } catch (e) {
+    console.error("Failed to parse pending auth state", e);
+    return null;
+  }
+};
+
+const savePendingLogout = (pending: PendingLogout) => {
+  if (typeof window === "undefined") return;
+  sessionStorage.setItem(
+    `${LOGOUT_STATE_PREFIX}${pending.state}`,
+    JSON.stringify(pending)
+  );
+};
+
+const consumePendingLogout = (state: string | null): PendingLogout | null => {
+  if (typeof window === "undefined" || !state) return null;
+  const key = `${LOGOUT_STATE_PREFIX}${state}`;
+  const raw = sessionStorage.getItem(key);
+  if (!raw) return null;
+  sessionStorage.removeItem(key);
+  try {
+    return JSON.parse(raw) as PendingLogout;
+  } catch (e) {
+    console.error("Failed to parse pending logout state", e);
+    return null;
+  }
+};
+
+const decodeJwtPayload = (token?: string): AuthProfile | undefined => {
+  if (!token) return undefined;
+  const parts = token.split(".");
+  if (parts.length < 2) return undefined;
+  try {
+    const payload = parts[1];
+    const decoded = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    const json = JSON.parse(decoded);
+    return {
+      name: json.name || json.given_name || json.family_name,
+      email: json.email,
+      phone_number: json.phone_number,
+      picture: json.picture,
+      preferred_username: json.preferred_username,
+    };
+  } catch (e) {
+    console.error("Unable to decode id_token", e);
+    return undefined;
+  }
+};
+
+export const getStoredTokens = (): AuthTokens | null => {
+  if (typeof window === "undefined") return null;
+  const raw = localStorage.getItem(AUTH_STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AuthTokens;
+  } catch (e) {
+    console.error("Failed to parse stored tokens", e);
+    return null;
+  }
+};
+
+export const persistTokens = (tokens: AuthTokens | null) => {
+  if (typeof window === "undefined") return;
+  if (!tokens) {
+    localStorage.removeItem(AUTH_STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(tokens));
+};
+
+const buildAuthorizeUrl = async (returnPath?: string) => {
+  const state = generateRandomString(16);
+  const codeVerifier = generateRandomString(64);
+  const codeChallenge = await sha256(codeVerifier);
+  const authorizeUrl = new URL(`${authConfig.authority}/connect/authorize`);
+
+  authorizeUrl.searchParams.set("client_id", authConfig.clientId);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("scope", authConfig.scope);
+  authorizeUrl.searchParams.set("redirect_uri", authConfig.redirectUri);
+  authorizeUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+  authorizeUrl.searchParams.set("state", state);
+
+  savePendingAuth({ state, codeVerifier, returnPath });
+  return authorizeUrl.toString();
+};
+
+export const startLoginRedirect = async (returnPath?: string) => {
+  if (typeof window === "undefined") return;
+  const target = await buildAuthorizeUrl(returnPath);
+  window.location.href = target;
+};
+
+const requestTokens = async (code: string, codeVerifier: string) => {
+  const tokenEndpoint = `${authConfig.authority}/connect/token`;
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: authConfig.clientId,
+    code,
+    redirect_uri: authConfig.redirectUri,
+    code_verifier: codeVerifier,
+  });
+
+  const response = await fetch(tokenEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Token endpoint error: ${response.status} ${errorText}`);
+  }
+
+  const json = await response.json();
+  const expiresInMs = (json.expires_in ? Number(json.expires_in) : 0) * 1000;
+  const expiresAt = Date.now() + expiresInMs;
+
+  const profile = decodeJwtPayload(json.id_token) || decodeJwtPayload(json.access_token);
+
+  const tokens: AuthTokens = {
+    accessToken: json.access_token,
+    refreshToken: json.refresh_token,
+    idToken: json.id_token,
+    expiresAt,
+    scope: json.scope,
+    tokenType: json.token_type,
+    profile,
+  };
+
+  persistTokens(tokens);
+  return tokens;
+};
+
+export const handleSignInCallback = async (url: string) => {
+  const currentUrl = new URL(url);
+  const code = currentUrl.searchParams.get("code");
+  const state = currentUrl.searchParams.get("state");
+  const error = currentUrl.searchParams.get("error");
+
+  if (error) {
+    throw new Error(error);
+  }
+
+  if (!code) {
+    throw new Error("Authorization code not found");
+  }
+
+  const pending = consumePendingAuth(state);
+  if (!pending?.codeVerifier) {
+    throw new Error("Missing or invalid PKCE state");
+  }
+
+  const tokens = await requestTokens(code, pending.codeVerifier);
+  return { tokens, returnPath: pending.returnPath || "/" };
+};
+
+export const refreshTokens = async (refreshToken: string): Promise<AuthTokens> => {
+  const tokenEndpoint = `${authConfig.authority}/connect/token`;
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    client_id: authConfig.clientId,
+    refresh_token: refreshToken,
+  });
+
+  const response = await fetch(tokenEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Refresh token error: ${response.status} ${errorText}`);
+  }
+
+  const json = await response.json();
+  const expiresInMs = (json.expires_in ? Number(json.expires_in) : 0) * 1000;
+  const expiresAt = Date.now() + expiresInMs;
+  const profile = decodeJwtPayload(json.id_token) || decodeJwtPayload(json.access_token);
+
+  const tokens: AuthTokens = {
+    accessToken: json.access_token,
+    refreshToken: json.refresh_token || refreshToken,
+    idToken: json.id_token,
+    expiresAt,
+    scope: json.scope,
+    tokenType: json.token_type,
+    profile,
+  };
+
+  persistTokens(tokens);
+  return tokens;
+};
+
+export const clearTokens = () => {
+  persistTokens(null);
+};
+
+export const startLogoutRedirect = (
+  idTokenHint?: string,
+  returnPath?: string
+) => {
+  if (typeof window === "undefined") return;
+  const state = generateRandomString(16);
+  savePendingLogout({ state, returnPath });
+
+  const url = new URL(`${authConfig.authority}/connect/endsession`);
+  url.searchParams.set("post_logout_redirect_uri", authConfig.postLogoutRedirectUri);
+  url.searchParams.set("state", state);
+  if (idTokenHint) {
+    url.searchParams.set("id_token_hint", idTokenHint);
+  }
+
+  window.location.href = url.toString();
+};
+
+export const handleSignOutCallback = (url: string) => {
+  const currentUrl = new URL(url);
+  const state = currentUrl.searchParams.get("state");
+  const pending = consumePendingLogout(state);
+  clearTokens();
+  return pending?.returnPath || "/";
+};
+
+export const useMemoizedProfile = (profile?: AuthProfile) =>
+  useMemo(() => profile, [profile]);


### PR DESCRIPTION
## Summary
- implement client-side PKCE/OIDC helpers and auth context to persist tokens and refresh sessions
- add dedicated OIDC sign-in and sign-out callback pages
- wrap the app with the auth provider and expose sign-in/sign-out controls in the header

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692098edb7288332b9eb0d3e64e1d7ac)