### PR TITLE
Show pending Invited/Applied labels on profile and team pages

### DIFF
--- a/goalise/messages/en.json
+++ b/goalise/messages/en.json
@@ -9,6 +9,8 @@
       "playerBasicInfo": {
         "age": "age",
         "inviteButtonText": "Invite",
+        "invitedLabelText": "Invited",
+        "invitedTooltip": "The player is already invited to your team.",
         "makeCaptainButtonText": "Make Captain",
         "quitTeamButtonText": "Quit Team"
       }
@@ -156,7 +158,9 @@
     "empty": "No teams to show at the moment.",
     "cannotCreateCaptain": "You are already the captain of {teamName}. Transfer the captain role and quit if you want to create a new team.",
     "cannotCreateDraft": "You already created a team, which is under review. You will be notified once we review it.",
-    "cannotCreateInTeam": "You are already in {teamName}. Quit if you want to create a new team."
+    "cannotCreateInTeam": "You are already in {teamName}. Quit if you want to create a new team.",
+    "appliedLabelText": "Applied",
+    "appliedTooltip": "You already applied to this team."
   },
   "playerProfile": {
     "title": "PlayerProfile",

--- a/goalise/messages/hy.json
+++ b/goalise/messages/hy.json
@@ -9,6 +9,8 @@
       "playerBasicInfo": {
         "age": "տարիք",
         "inviteButtonText": "Հրավիրել",
+        "invitedLabelText": "Հրավիրված է",
+        "invitedTooltip": "Խաղացողն արդեն հրավիրված է ձեր թիմ։",
         "makeCaptainButtonText": "Նշանակել կապիտան",
         "quitTeamButtonText": "Լքել թիմը"
       }
@@ -156,7 +158,9 @@
     "empty": "Ներկայումս ցուցադրելու թիմ չկա։",
     "cannotCreateCaptain": "Դուք արդեն {teamName} թիմի կապիտանն եք։ Կապիտանի դերը փոխանցեք և լքեք, եթե ցանկանում եք ստեղծել նոր թիմ։",
     "cannotCreateDraft": "Դուք արդեն ստեղծել եք թիմ, որն ստուգման փուլում է։ Կկտեղեկացվեք ստուգումից հետո։",
-    "cannotCreateInTeam": "Դուք արդեն {teamName} թիմի անդամ եք։ Լքեք, եթե ցանկանում եք ստեղծել նոր թիմ։"
+    "cannotCreateInTeam": "Դուք արդեն {teamName} թիմի անդամ եք։ Լքեք, եթե ցանկանում եք ստեղծել նոր թիմ։",
+    "appliedLabelText": "Հայտը ներկայացված է",
+    "appliedTooltip": "Դուք արդեն հայտ եք ներկայացրել այս թիմին։"
   },
   "playerProfile": {
     "title": "Խաղացողի պրոֆիլ",

--- a/goalise/src/components/PlayerProfile/PlayerProfile.tsx
+++ b/goalise/src/components/PlayerProfile/PlayerProfile.tsx
@@ -87,6 +87,15 @@ export const PlayerProfile = () => {
     : undefined;
   const isLoggedIn = Boolean(userInfo);
 
+  const viewedPlayerId = playerBasicInfo?.playerInfo.id;
+  const isAlreadyInvited = Boolean(
+    isUserCaptain &&
+      viewedPlayerId !== undefined &&
+      userInfo?.relationshipState?.pendingInvitedPlayerIds?.includes(
+        viewedPlayerId,
+      ),
+  );
+
   const viewerTeamId = userInfo?.playerInfo.team?.id;
   const viewedTeamId = playerBasicInfo?.playerInfo.team?.id;
   const isSameTeam =
@@ -162,6 +171,9 @@ export const PlayerProfile = () => {
             teamId={playerBasicInfo?.playerInfo.team?.id}
             isLoggedIn={isLoggedIn}
             playerHasTeam={Boolean(playerBasicInfo?.playerInfo.team)}
+            isAlreadyInvited={isAlreadyInvited}
+            invitedLabelText={t("invitedLabelText")}
+            invitedTooltipText={t("invitedTooltip")}
           />
         </div>
         {isLoadingPlayerInfo && (

--- a/goalise/src/entities/PendingActionLabel/PendingActionLabel.tsx
+++ b/goalise/src/entities/PendingActionLabel/PendingActionLabel.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { ClickAwayListener, Tooltip } from "@mui/material";
+import leaguesHeaderStyles from "@/components/LeaguesHeader/LeaguesHeader.module.css";
+import joinedIcon from "@/assets/pngs/joinedIcon.svg";
+
+interface PendingActionLabelProps {
+  text: string;
+  tooltipText: string;
+}
+
+export const PendingActionLabel: React.FC<PendingActionLabelProps> = ({
+  text,
+  tooltipText,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <ClickAwayListener onClickAway={() => setOpen(false)}>
+      <Tooltip
+        title={tooltipText}
+        open={open}
+        arrow
+        disableHoverListener
+        disableFocusListener
+        disableTouchListener
+        onClose={() => setOpen(false)}
+        slotProps={{ tooltip: { sx: { fontSize: 13 } } }}
+      >
+        <div
+          className={leaguesHeaderStyles.joinedButton}
+          style={{ cursor: "default" }}
+          onMouseEnter={() => setOpen(true)}
+          onMouseLeave={() => setOpen(false)}
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          <div className={leaguesHeaderStyles.joinedButtonWrapper}>
+            <Image
+              className={leaguesHeaderStyles.joinedButtonIcon}
+              src={joinedIcon}
+              alt=""
+            />
+            <div className={leaguesHeaderStyles.stageButtonName}>{text}</div>
+          </div>
+        </div>
+      </Tooltip>
+    </ClickAwayListener>
+  );
+};

--- a/goalise/src/entities/PendingActionLabel/index.ts
+++ b/goalise/src/entities/PendingActionLabel/index.ts
@@ -1,0 +1,3 @@
+import { PendingActionLabel } from "./PendingActionLabel";
+
+export default PendingActionLabel;

--- a/goalise/src/entities/PlayerProfileCard/PlayerProfileCard.tsx
+++ b/goalise/src/entities/PlayerProfileCard/PlayerProfileCard.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 import Link from "next/link";
 import PlayerStatistics from "../PlayerStatistics";
 import UnassignedPlayerCard from "../UnassignedPlayerCard";
+import PendingActionLabel from "../PendingActionLabel";
 import { MEDIA_TABLET_SMALL } from "@/constants/windowSizes";
 import { useWindowSize } from "@/hooks/useWindowSize";
 import { useTranslations } from "next-intl";
@@ -37,6 +38,9 @@ export const PlayerProfileCard: React.FC<IPlayerProfileProps> = ({
   playerHasTeam,
   isLoggedIn,
   teamId,
+  isAlreadyInvited,
+  invitedLabelText,
+  invitedTooltipText,
 }) => {
   const { width } = useWindowSize();
   const isMobile = width <= MEDIA_TABLET_SMALL;
@@ -104,15 +108,22 @@ export const PlayerProfileCard: React.FC<IPlayerProfileProps> = ({
                 {!isMobile &&
                   (!isSameTeam || !playerHasTeam) &&
                   !isViewingSelf &&
-                  onInviteButtonClick &&
-                  inviteButtonText && (
-                    <Button
-                      className="blue_button_transparant"
-                      content={inviteButtonText}
-                      handleClick={onInviteButtonClick}
-                      icon={plusButtonImg}
-                    />
-                  )}
+                  (isAlreadyInvited
+                    ? invitedLabelText && (
+                        <PendingActionLabel
+                          text={invitedLabelText}
+                          tooltipText={invitedTooltipText ?? ""}
+                        />
+                      )
+                    : onInviteButtonClick &&
+                      inviteButtonText && (
+                        <Button
+                          className="blue_button_transparant"
+                          content={inviteButtonText}
+                          handleClick={onInviteButtonClick}
+                          icon={plusButtonImg}
+                        />
+                      ))}
                 <div className={isMobile ? styles.nameWrapper : ""}>
                   <div className={isMobile ? styles.numberNameWrapper : ""}>
                     {" "}
@@ -144,15 +155,22 @@ export const PlayerProfileCard: React.FC<IPlayerProfileProps> = ({
                     {isMobile &&
                       (!isSameTeam || !playerHasTeam) &&
                       !isViewingSelf &&
-                      onInviteButtonClick &&
-                      inviteButtonText && (
-                        <Button
-                          className="blue_button_transparant"
-                          content={inviteButtonText}
-                          handleClick={onInviteButtonClick}
-                          icon={plusButtonImg}
-                        />
-                      )}
+                      (isAlreadyInvited
+                        ? invitedLabelText && (
+                            <PendingActionLabel
+                              text={invitedLabelText}
+                              tooltipText={invitedTooltipText ?? ""}
+                            />
+                          )
+                        : onInviteButtonClick &&
+                          inviteButtonText && (
+                            <Button
+                              className="blue_button_transparant"
+                              content={inviteButtonText}
+                              handleClick={onInviteButtonClick}
+                              icon={plusButtonImg}
+                            />
+                          ))}
                   </div>
                 </div>
               </div>
@@ -191,7 +209,13 @@ export const PlayerProfileCard: React.FC<IPlayerProfileProps> = ({
             )}
             {!playerHasTeam && (
               <div className={styles.unassignedContainer}>
-                <UnassignedPlayerCard onClick={isViewingSelf ? undefined : onInviteButtonClick} />
+                <UnassignedPlayerCard
+                  onClick={
+                    isViewingSelf || isAlreadyInvited
+                      ? undefined
+                      : onInviteButtonClick
+                  }
+                />
               </div>
             )}
           </div>

--- a/goalise/src/entities/PlayerProfileCard/PlayerProfileCard.types.ts
+++ b/goalise/src/entities/PlayerProfileCard/PlayerProfileCard.types.ts
@@ -51,4 +51,7 @@ export interface IPlayerProfileProps {
   onQuitTeamButtonClick?: () => void;
   playerHasTeam?: boolean;
   teamId?: number;
+  isAlreadyInvited?: boolean;
+  invitedLabelText?: string;
+  invitedTooltipText?: string;
 }

--- a/goalise/src/entities/TeamOverviewHeader/TeamOverviewHeader.tsx
+++ b/goalise/src/entities/TeamOverviewHeader/TeamOverviewHeader.tsx
@@ -21,7 +21,9 @@ import {
 import { useAuth } from "@/shared/auth/AuthContext";
 import { refreshTokens } from "@/shared/auth/oidcService";
 import PlayerInvitationCard from "@/entities/PlayerInvitationCard";
+import PendingActionLabel from "@/entities/PendingActionLabel";
 import { UpdateTeamPopUp } from "@/entities/UpdateTeamPopUp/UpdateTeamPopUp";
+import { useTranslations } from "next-intl";
 
 const isValidUrl = (url: string): boolean => {
   try {
@@ -52,6 +54,7 @@ export const TeamOverviewHeader: React.FC = () => {
   const pathname = usePathname();
   const id = Number(teamId);
   const base = `/teams/${teamId}`;
+  const tTeams = useTranslations("teams");
 
   const {
     data: teamInfo,
@@ -112,6 +115,11 @@ export const TeamOverviewHeader: React.FC = () => {
     !isAuthenticated ||
     (isAuthenticated && !isUserInfoLoading && !isOnThisTeam);
 
+  const isAlreadyApplied = Boolean(
+    isAuthenticated &&
+      userInfo?.relationshipState?.pendingAppliedTeamIds?.includes(id),
+  );
+
   const handleApplyClick = () => {
     if (!isAuthenticated) {
       signIn();
@@ -128,6 +136,8 @@ export const TeamOverviewHeader: React.FC = () => {
     try {
       await applyToTeamMutation({ teamId: id }).unwrap();
       setShowApplySuccessModal(true);
+      refetchUserInfo();
+      refetchTeamInfo();
     } catch (error) {
       const errorData = error as { data?: { errorMessage?: string } };
       setApplyError(
@@ -136,7 +146,7 @@ export const TeamOverviewHeader: React.FC = () => {
       );
       setShowApplyErrorModal(true);
     }
-  }, [id, applyToTeamMutation]);
+  }, [id, applyToTeamMutation, refetchUserInfo, refetchTeamInfo]);
 
   const quitTeam = useCallback(async () => {
     if (!userTeamId) return;
@@ -253,13 +263,19 @@ export const TeamOverviewHeader: React.FC = () => {
                 </div>
               ) : (
                 <>
-                  {showApplyButton && (
-                    <Button
-                      handleClick={handleApplyClick}
-                      content="Apply"
-                      className="red_button_transparant_white_text"
-                    />
-                  )}
+                  {showApplyButton &&
+                    (isAlreadyApplied ? (
+                      <PendingActionLabel
+                        text={tTeams("appliedLabelText")}
+                        tooltipText={tTeams("appliedTooltip")}
+                      />
+                    ) : (
+                      <Button
+                        handleClick={handleApplyClick}
+                        content="Apply"
+                        className="red_button_transparant_white_text"
+                      />
+                    ))}
                   {isOnThisTeam && (
                     <Button
                       handleClick={() => setShowQuitConfirmModal(true)}

--- a/goalise/src/types/api/userInfo.ts
+++ b/goalise/src/types/api/userInfo.ts
@@ -1,6 +1,12 @@
 export interface IPlayerProfile {
   playerInfo: IPlayerInfo;
   profileCompletionInfo: IProfileCompletionInfo;
+  relationshipState: IRelationshipState;
+}
+
+export interface IRelationshipState {
+  pendingAppliedTeamIds: number[];
+  pendingInvitedPlayerIds: number[];
 }
 
 export interface IPlayerInfo {


### PR DESCRIPTION
Reads relationshipState from /players/me to detect pending invites/applications and replaces the Invite/Apply buttons with disabled-looking labels (with tooltip) when the action would be a duplicate. Also hides the Free Agent "Send Invite" CTA when the player is already invited, and refetches user/team info after a successful apply so the label updates immediately.